### PR TITLE
A quick fix to resolve transifex update source 400 error 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "pot-merge",
+  "version": "2.2.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "pot-merge",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Use for merging of pot-files. Takes care of contexttags",
   "main": "pot-merge.js",
   "bin": "cli.js",
   "dependencies": {
-    "extend": "^3.0.1",
     "promise": "^7.0.4",
     "yargs": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "pot-merge.js",
   "bin": "cli.js",
   "dependencies": {
+    "extend": "^3.0.1",
     "promise": "^7.0.4",
     "yargs": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pot-merge",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Use for merging of pot-files. Takes care of contexttags",
   "main": "pot-merge.js",
   "bin": "cli.js",

--- a/pot-merge.js
+++ b/pot-merge.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var fs = require('fs');
 var Promise = require('promise');
-
+var extend = require('extend')
 
 var readFile = Promise.denodeify(fs.readFile);
 
@@ -107,7 +107,8 @@ Block.prototype.hash = function() {
          duplicate.merge(block);
      else {
         try {
-            var msgidValue = block["msgid"]
+            var blockCopy = extend({}, block)
+            var msgidValue = blockCopy["msgid"]
             msgidValue[0].replace('msgid', 'msgstr')
             block["msgstr"] = msgidValue
             this.blocks.push(block);

--- a/pot-merge.js
+++ b/pot-merge.js
@@ -107,8 +107,9 @@ Block.prototype.hash = function() {
          duplicate.merge(block);
      else {
         try {
-            let msgidValue = block["msgid"][0].split(" ")[1]
-            block['msgstr'] = [new String('msgstr ' + msgidValue)]
+            var msgidValue = block["msgid"]
+            msgidValue[0].replace('msgid', 'msgstr')
+            block["msgstr"] = msgidValue
             this.blocks.push(block);
         } catch (e) {
             console.log(e);
@@ -120,7 +121,6 @@ SetOfBlocks.prototype.getDuplicate = function(hash) {
     for (var i = 0; i<this.blocks.length;i++)
         if (this.blocks[i].hash() === hash)
             return this.blocks[i];
-
         return;
     }
 

--- a/pot-merge.js
+++ b/pot-merge.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 var fs = require('fs');
 var Promise = require('promise');
-var extend = require('extend')
 
 var readFile = Promise.denodeify(fs.readFile);
 
@@ -107,8 +106,7 @@ Block.prototype.hash = function() {
          duplicate.merge(block);
      else {
         try {
-            var blockCopy = extend({}, block)
-            var msgidValue = blockCopy["msgid"]
+            var msgidValue = [].concat(block['msgid'])
             msgidValue[0].replace('msgid', 'msgstr')
             block["msgstr"] = msgidValue
             this.blocks.push(block);

--- a/pot-merge.js
+++ b/pot-merge.js
@@ -72,7 +72,7 @@ Block.prototype.hash = function() {
     // In case of a plural block, `this.msgid` will contain both msgid and
     // msgid_plural. Extract only msgid, since it's the unique identifier.
     var msgid = this.msgid.length > 0 ? buildMsgid(this.msgid) : [];
-    
+
     var strToHash = msgid + this.msgctx;
 
     var hash = 0, i, chr, len;
@@ -107,6 +107,8 @@ Block.prototype.hash = function() {
          duplicate.merge(block);
      else {
         try {
+            let msgidValue = block["msgid"][0].split(" ")[1]
+            block['msgstr'] = [new String('msgstr ' + msgidValue)]
             this.blocks.push(block);
         } catch (e) {
             console.log(e);
@@ -117,7 +119,7 @@ Block.prototype.hash = function() {
 SetOfBlocks.prototype.getDuplicate = function(hash) {
     for (var i = 0; i<this.blocks.length;i++)
         if (this.blocks[i].hash() === hash)
-            return this.blocks[i];      
+            return this.blocks[i];
 
         return;
     }


### PR DESCRIPTION
Transifex's update source api stop receiving po file with empty msgstr lines.
Duplicate value of msgid to msgstr if msgstr is empty to resolve it.